### PR TITLE
chore: Remove obsolete Next.js configuration flags

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,12 +15,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  // Configuración para archivos estáticos
-  experimental: {
-    appDir: true,
-  },
-  // Asegurar que los archivos estáticos se copien correctamente
-  distDir: 'out',
 };
 
 // Exporta la configuración envuelta con el plugin de next-intl


### PR DESCRIPTION
Remove experimental.appDir (stable in Next 15) and redundant distDir setting. Clean up comments referencing old workarounds.