### PR TITLE
feat: Update skills list and IconCarousel with current stack

### DIFF
--- a/components/IconCarousel.tsx
+++ b/components/IconCarousel.tsx
@@ -1,15 +1,19 @@
 'use client'
 import React from 'react';
-import { 
-  SiJavascript, SiReact, SiNodedotjs, SiExpress, SiNextdotjs, 
-  SiVuedotjs, SiPostgresql, SiMongodb, SiHtml5, SiCss3, 
-  SiStyledcomponents, SiTailwindcss, SiGit
+import {
+  SiJavascript, SiTypescript, SiReact, SiNextdotjs,
+  SiNodedotjs, SiExpress, SiNestjs, SiPrisma,
+  SiLaravel, SiPhp, SiPostgresql, SiMongodb,
+  SiHtml5, SiCss3, SiTailwindcss, SiStyledcomponents,
+  SiDocker, SiGit
 } from 'react-icons/si';
 
 const icons = [
-  SiJavascript, SiReact, SiNodedotjs, SiExpress, SiNextdotjs,
-  SiVuedotjs, SiPostgresql, SiMongodb, SiHtml5, SiCss3,
-  SiStyledcomponents, SiTailwindcss, SiGit
+  SiJavascript, SiTypescript, SiReact, SiNextdotjs,
+  SiNodedotjs, SiExpress, SiNestjs, SiPrisma,
+  SiLaravel, SiPhp, SiPostgresql, SiMongodb,
+  SiHtml5, SiCss3, SiTailwindcss, SiStyledcomponents,
+  SiDocker, SiGit
 ];
 
 const IconCarousel: React.FC = () => {

--- a/components/about-me.tsx
+++ b/components/about-me.tsx
@@ -12,10 +12,11 @@ export default function AboutMe() {
   }, []);
   
   const skills = [
-    "JavaScript (ES6+)", "React", "Node.js", "Express", 
-    "Next.js", "VUE", "PostgreSQL", "MongoDB",
-    "HTML5", "CSS3", "Styled Components", "Tailwind CSS",
-    "Git", "Agile Methodologies", "Scrum", "CI/CD"
+    "JavaScript (ES6+)", "TypeScript", "React", "Next.js",
+    "Node.js", "Express", "NestJS", "Prisma",
+    "Laravel", "PHP", "PostgreSQL", "MongoDB",
+    "HTML5", "CSS3", "Tailwind CSS", "Styled Components",
+    "Docker", "Git", "Agile Methodologies", "Scrum", "CI/CD"
   ]
   
   return (

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,8 +4,8 @@
   "aboutMe": {
     "section": "About Me",
     "heading": "About Me",
-    "intro": "Hello! I'm Tomas, a passionate fullstack developer with a keen interest in building digital experiences that make a difference. My journey in tech started back in 2020, and since then, I've had the privilege of learning a diverse range of technologies and projects.",
-    "focus": "My focus is on creating efficient, scalable, and user-friendly solutions. I love diving into complex problems and emerging with elegant solutions. Whether it's crafting responsive front-end interfaces or architecting robust back-end systems, I'm always excited to take on new challenges.",
+    "intro": "Hi! I'm Tomás, a fullstack developer. My programming foundations were built during an unfinished game development degree: syntax, data structures, and capstone projects like Conway's Game of Life in C++, Java and C#. During the pandemic, I pivoted to web development through intensive bootcamps and courses. My first freelance experiences were technically shallow (WordPress, static sites, and personal React/Next.js projects). The exponential professional growth came when I joined ForIT, tackling real problems in production projects with real clients.",
+    "focus": "Today I focus on writing maintainable, scalable code with a sense of purpose. I work with full stacks (TypeScript + React, NestJS + Prisma + Next.js, React Native + Capacitor) on real products with real users. I'm passionate about architecture problems, code quality, and technical decisions with measurable impact.",
     "skillsTitle": "Skills & Technologies"
   },
   "contact": "Contact",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,8 +4,8 @@
   "aboutMe": {
     "section": "Sobre mí",
     "heading": "Sobre mí",
-    "intro": "¡Hola! Soy Tomás, un desarrollador fullstack apasionado con gran interés en construir experiencias digitales que marquen la diferencia. Mi camino en la tecnología comenzó en 2020 y desde entonces he tenido el privilegio de aprender una amplia gama de tecnologías y proyectos.",
-    "focus": "Mi enfoque está en crear soluciones eficientes, escalables y fáciles de usar. Me encanta enfrentarme a problemas complejos y encontrar soluciones elegantes. Ya sea creando interfaces front-end responsivas o diseñando sistemas back-end robustos, siempre estoy emocionado de asumir nuevos desafíos.",
+    "intro": "¡Hola! Soy Tomás, desarrollador fullstack. Mis bases en programación las construí cursando una carrera inconclusa de desarrollo de videojuegos: sintaxis, estructuras de datos en C#, C++ y Java. Durante la pandemia pivoté hacia el desarrollo web a través de bootcamps y cursos intensivos. Mis primeras experiencias freelance de poca profundidad técnica (WordPress, sitios estáticos y proyectos personales en React/Next.js). El crecimiento profesional exponencial llegó al empezar a trabajar en ForIT, enfrentando problemas reales en proyectos productivos con clientes.",
+    "focus": "Hoy me enfoco en escribir código mantenible, escalable y con sentido de propósito. Trabajo con stacks completos (TypeScript + React, NestJS + Prisma + Next.js, React Native + Capacitor) sobre productos reales con usuarios reales. Me apasionan los problemas de arquitectura, la calidad del código y las decisiones técnicas con impacto medible.",
     "skillsTitle": "Habilidades y Tecnologías"
   },
   "contact": "Contacto",


### PR DESCRIPTION
Sync portfolio personal   
  info with current reality:
  
  **Skills list** (about-me.tsx):
  - Add: TypeScript, NestJS, Prisma, Laravel, PHP, Docker
  - Remove: VUE (not used in recent projects)
  
  **IconCarousel** (IconCarousel.tsx):
  - Add icons for: TypeScript, NestJS, Prisma, Laravel, PHP, Docker
  - Remove: Vue
  
  **About-me narrative** (messages/{es,en}.json):
  - Replace generic 'started in 2020' intro with concrete growth story: self-taught from unfinished game dev degree (C++/Java/C#, Conway's Game of     
  Life), pandemic pivot to web via bootcamps, shallow freelance period, exponential growth at ForIT.
  - Update focus to mention current real stacks (TypeScript + React, NestJS + Prisma + Next.js, React Native + Capacitor).