### PR TITLE
feat: Add Globant-ForIT 2026 mentorship to Learning Path

### DIFF
--- a/components/learning-path.tsx
+++ b/components/learning-path.tsx
@@ -12,6 +12,14 @@ export default function LearningPath() {
 
   const learningTimeline = [
     {
+      program: t('mentoria'),
+      institution: "Globant-ForIT 2026",
+      date: "APRIL 2026 - PRESENT",
+      description: [
+        t('mentoriaDesc1')
+      ]
+    },
+    {
       program: t('bachelor'),
       institution: "UNSAM",
       date: "MARCH 2024 - PRESENT",

--- a/messages/en.json
+++ b/messages/en.json
@@ -59,6 +59,8 @@
   "learningPath": {
     "section": "Education",
     "heading": "My Learning Path",
+    "mentoria": "Professional Mentorship",
+    "mentoriaDesc1": "5-month mentorship focused on technical growth, interview preparation, and parallel projects.",
     "bachelor": "Bachelor's degree in Data Science",
     "bachelorDesc1": "Currently pursuing a Bachelor's degree in Data Science at UNSAM.",
     "bachelorDesc2": "My goal is to acquire data analysis skills to solve real-world problems and contribute to the development of innovative solutions.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -59,6 +59,8 @@
   "learningPath": {
     "section": "Educación",
     "heading": "Mi Trayectoria Académica",
+    "mentoria": "Mentoría Profesional",
+    "mentoriaDesc1": "Mentoría de 5 meses con foco en crecimiento técnico, preparación para entrevistas y proyectos paralelos.",
     "bachelor": "Licenciatura en Ciencia de Datos",
     "bachelorDesc1": "Actualmente cursando la Licenciatura en Ciencia de Datos en UNSAM.",
     "bachelorDesc2": "Mi objetivo es adquirir habilidades de análisis de datos para resolver problemas reales y contribuir al desarrollo de soluciones innovadoras.",


### PR DESCRIPTION
Add ongoing 5-month professional mentorship program as the first entry in Learning Path (APRIL 2026 - PRESENT). Framed institutionally  (Globant-ForIT 2026, no mentor name) with a single brief description bullet covering technical growth, interview prep and parallel projects. Bilingual support via existing i18n structure.